### PR TITLE
feat: adds new procedure types to model

### DIFF
--- a/aind-sharepoint-service-server/src/aind_sharepoint_service_server/main.py
+++ b/aind-sharepoint-service-server/src/aind_sharepoint_service_server/main.py
@@ -11,7 +11,6 @@ from fastapi.routing import APIRoute
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from fastapi_cache.backends.redis import RedisBackend
-from starlette.routing import Mount
 
 # from redis import asyncio as aioredis  # noqa
 from redis.asyncio import from_url  # noqa

--- a/aind-sharepoint-service-server/src/aind_sharepoint_service_server/main.py
+++ b/aind-sharepoint-service-server/src/aind_sharepoint_service_server/main.py
@@ -11,6 +11,7 @@ from fastapi.routing import APIRoute
 from fastapi_cache import FastAPICache
 from fastapi_cache.backends.inmemory import InMemoryBackend
 from fastapi_cache.backends.redis import RedisBackend
+from starlette.routing import Mount
 
 # from redis import asyncio as aioredis  # noqa
 from redis.asyncio import from_url  # noqa
@@ -61,6 +62,6 @@ app.add_middleware(
 app.include_router(router)
 
 # Clean up the methods names that is generated in the client code
-for route in app.routes:
+for route in router.routes:
     if isinstance(route, APIRoute):
         route.operation_id = route.name

--- a/aind-sharepoint-service-server/src/aind_sharepoint_service_server/models/nsb_2023.py
+++ b/aind-sharepoint-service-server/src/aind_sharepoint_service_server/models/nsb_2023.py
@@ -784,7 +784,6 @@ class NSB2023Procedure(Enum, metaclass=EnumMeta):
     WHC_2_P = "WHC 2P"
     WHC_NP = "WHC NP"
 
-
     # Missing attributes after Sx NSB2023Procedure # Removal
     MOTOR_CTX_2_P = "Motor Ctx 2P"
     GRID_INJ_6_OR_9_VISUAL = "Grid INJ (6 or 9) + Visual Ctx 2P"

--- a/aind-sharepoint-service-server/src/aind_sharepoint_service_server/models/nsb_2023.py
+++ b/aind-sharepoint-service-server/src/aind_sharepoint_service_server/models/nsb_2023.py
@@ -784,6 +784,7 @@ class NSB2023Procedure(Enum, metaclass=EnumMeta):
     WHC_2_P = "WHC 2P"
     WHC_NP = "WHC NP"
 
+
     # Missing attributes after Sx NSB2023Procedure # Removal
     MOTOR_CTX_2_P = "Motor Ctx 2P"
     GRID_INJ_6_OR_9_VISUAL = "Grid INJ (6 or 9) + Visual Ctx 2P"
@@ -799,6 +800,16 @@ class NSB2023Procedure(Enum, metaclass=EnumMeta):
     EMG__ARRAY = "EMG Array"
     TESTES__INJECTION = "Testes Injection"
     OVIDUCT__INJECTION = "Oviduct Injection"
+
+    # Additional procedure types
+    THERMISTOR__IMPLANT_WITH = "Thermistor Implant (with Headpost)"
+    HP_INJ__THERMISTOR__IMPLA = "HP + INJ + Thermistor Implant"
+    WHC_NP__THERMISTOR__IMPLA = "WHC NP + Thermistor Implant"
+    DHC__THERMISTOR__IMPLANT = "DHC + Thermistor Implant"
+    SPINAL__CORD_INJ = "Spinal Cord INJ"
+    CHRONOS = "Chronos"
+    ΜLED__IMPLANTATION = "µLED Implantation"
+    CHRONOS_HP__SKULL__SCREW = "Chronos HP + Skull Screw + Thermistor Implant"
 
 
 class NSB2023Headpost(Enum, metaclass=EnumMeta):

--- a/aind-sharepoint-service-server/tests/conftest.py
+++ b/aind-sharepoint-service-server/tests/conftest.py
@@ -92,24 +92,26 @@ def client_with_redis() -> Generator[TestClient, Any, None]:
     """Creating a client when settings have a redis_url. Only used in one test
     to verify the lifespan method in main is called correctly."""
 
-    # Import moved to be able to mock cache
-    from aind_sharepoint_service_server.main import app
-
     settings_with_redis = settings.model_copy(
         update={"redis_url": RedisDsn("redis://example.com:1234")}, deep=True
     )
+    mock_redis = AsyncMock()
     with (
         patch(
             "aind_sharepoint_service_server.main.settings",
-            return_value=settings_with_redis,
+            settings_with_redis,
         ),
         patch(
-            "aind_sharepoint_service_server.main.from_url", return_value=None
+            "aind_sharepoint_service_server.main.from_url",
+            return_value=mock_redis,
         ),
         patch(
             "aind_sharepoint_service_server.main.RedisBackend",
             return_value=None,
         ),
     ):
+        # Import moved inside patch context to ensure settings are patched
+        from aind_sharepoint_service_server.main import app
+
         with TestClient(app) as c:
             yield c

--- a/aind-sharepoint-service-server/tests/test_main.py
+++ b/aind-sharepoint-service-server/tests/test_main.py
@@ -13,17 +13,18 @@ class TestMain:
         """Tests client is instantiated correctly when redis_url None."""
         response = client.get("/healthcheck")
         assert 200 == response.status_code
-    
+
     def test_app_with_redis(self, client_with_redis: TestClient):
         """Tests client is instantiated correctly when redis_url set."""
         response = client_with_redis.get("/healthcheck")
         assert 200 == response.status_code
-    
+
     def test_operation_ids_are_set(self, client: TestClient):
         """Test that operation_id is set to route name for all APIRoutes."""
         api_routes = [r for r in router.routes if isinstance(r, APIRoute)]
         assert len(api_routes) > 0
         assert all(r.operation_id == r.name for r in api_routes)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/aind-sharepoint-service-server/tests/test_main.py
+++ b/aind-sharepoint-service-server/tests/test_main.py
@@ -1,22 +1,29 @@
 """Module to test main app"""
 
 import pytest
+from fastapi.routing import APIRoute
 from fastapi.testclient import TestClient
+from aind_sharepoint_service_server.route import router
 
 
 class TestMain:
     """Tests app endpoints"""
 
-    def test_app_with_redis(self, client_with_redis: TestClient):
-        """Tests client is instantiated correctly when redis_url set."""
-        response = client_with_redis.get("/healthcheck")
-        assert 200 == response.status_code
-
     def test_app_with_in_memory_cache(self, client: TestClient):
         """Tests client is instantiated correctly when redis_url None."""
         response = client.get("/healthcheck")
         assert 200 == response.status_code
-
+    
+    def test_app_with_redis(self, client_with_redis: TestClient):
+        """Tests client is instantiated correctly when redis_url set."""
+        response = client_with_redis.get("/healthcheck")
+        assert 200 == response.status_code
+    
+    def test_operation_ids_are_set(self, client: TestClient):
+        """Test that operation_id is set to route name for all APIRoutes."""
+        api_routes = [r for r in router.routes if isinstance(r, APIRoute)]
+        assert len(api_routes) > 0
+        assert all(r.operation_id == r.name for r in api_routes)
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
related to https://github.com/AllenNeuralDynamics/aind-metadata-service/issues/697

Right now VR foraging uploads are being blocked because of unmapped procedures because they fall under new procedure types that are being mapped to None since they don't exist in our current NSB2023Procedure model def. 

This PR:
- adds latest options for Procedure Type selection from NSB to the model
- Latest dependencies led to coverage tools detecting that the operation_id assignment loop was never executed/tested so adds a test and fixes routes loop (routes are defined on the APIRouter instance)

After this, can update `has_hp_procedure` in aind-metadata-service to recognize the HPs. This will unblock those uploads